### PR TITLE
Fix: corrected keyword matching and implemented tokenize function in …

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -66,7 +66,7 @@ impl Lexer {
                             "char" | "else" | "enum" | "if" | "int" | "return" |
                             "sizeof" | "while" | "open" | "read" | "close" | 
                             "printf" | "malloc" | "free" | "memset" | "memcmp" | 
-                            "exit" | "void" | "main" => Token::Keyword(ident),
+                            "exit" | "void"  => Token::Keyword(ident),
                             _ => Token::Id(ident),
                         }
                     }
@@ -273,5 +273,20 @@ impl Lexer {
         }
 
         Token::Unknown('"') // unterminated string
+    }
+    /// Tokenizes the entire input and returns a vector of tokens.
+    pub fn tokenize(&mut self) -> Vec<Token> {
+        let mut tokens = Vec::new();
+
+        loop {
+            let token = self.next_token();
+            if token == Token::EOF {
+                tokens.push(Token::EOF);
+                break;
+            }
+            tokens.push(token);
+        }
+
+        tokens
     }
 }

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -78,3 +78,29 @@ fn test_skip_comments() {
     assert_eq!(lexer.next_token(), Token::Keyword("int".to_string()));
     assert_eq!(lexer.next_token(), Token::EOF);
 }
+#[test]
+fn test_unknown_character() {
+    let mut lexer = Lexer::new("@");
+    assert_eq!(lexer.next_token(), Token::Unknown('@'));
+    assert_eq!(lexer.next_token(), Token::EOF);
+}
+#[test]
+fn test_tokenize_full_line() {
+    let mut lexer = Lexer::new("int main() { return 42; }");
+    let tokens = lexer.tokenize();
+    let expected = vec![
+        Token::Keyword("int".to_string()),
+        Token::Id("main".to_string()),                   
+        Token::Operator("(".to_string()),
+        Token::Operator(")".to_string()),
+        Token::Operator("{".to_string()),
+        Token::Keyword("return".to_string()),
+        Token::Num(42),
+        Token::Operator(";".to_string()),
+        Token::Operator("}".to_string()),
+        Token::EOF,
+    ];
+    assert_eq!(tokens, expected);
+}
+
+


### PR DESCRIPTION
lexer
Description
This pull request implements and finalizes the tokenize() function in the lexer.rs file. It also fixes a bug in the keyword matching logic that previously misclassified main and other identifiers.

Changes made:
Added support for full token stream generation via tokenize().

Updated next_token() logic to accurately distinguish between keywords and identifiers.

Fixed unit test failure in test_tokenize_full_line.

All lexer unit tests now pass successfully.

These updates improve the reliability of token parsing and prepare the lexer for integration with the parser.